### PR TITLE
remove main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "version": "0.0.18",
   "homepage": "https://github.com/mpneuried/mpbasic",
   "private": false,
-  "main": "/index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/mpneuried/mpbasic.git"


### PR DESCRIPTION
Starting with a slash causes an error when running the code. Removed it as it defaults to `index.js` anyway.